### PR TITLE
feat: native iOS-Features ergänzen (Guideline 4.2 Rejection-Risiko senken)

### DIFF
--- a/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "5a7a9593eefb99783ae948296fc3be757b16ce07d14086a01c10f6cfd9337405",
+  "pins" : [
+    {
+      "identity" : "capacitor-swift-pm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ionic-team/capacitor-swift-pm.git",
+      "state" : {
+        "revision" : "44ae2505f54a80c5e559533950886d0644fc2fca",
+        "version" : "8.4.0"
+      }
+    },
+    {
+      "identity" : "ion-ios-geolocation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ionic-team/ion-ios-geolocation.git",
+      "state" : {
+        "revision" : "db363927d3a954e3ea24d2e72b6e9814769a84be",
+        "version" : "2.1.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -11,14 +11,20 @@ let package = Package(
             targets: ["CapApp-SPM"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.4.0")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", exact: "8.4.0"),
+        .package(name: "CapacitorGeolocation", path: "../../../node_modules/@capacitor/geolocation"),
+        .package(name: "CapacitorHaptics", path: "../../../node_modules/@capacitor/haptics"),
+        .package(name: "CapacitorShare", path: "../../../node_modules/@capacitor/share")
     ],
     targets: [
         .target(
             name: "CapApp-SPM",
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
-                .product(name: "Cordova", package: "capacitor-swift-pm")
+                .product(name: "Cordova", package: "capacitor-swift-pm"),
+                .product(name: "CapacitorGeolocation", package: "CapacitorGeolocation"),
+                .product(name: "CapacitorHaptics", package: "CapacitorHaptics"),
+                .product(name: "CapacitorShare", package: "CapacitorShare")
             ]
         )
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,10 @@
       "version": "1.0.0",
       "dependencies": {
         "@capacitor/core": "^8.4.0",
+        "@capacitor/geolocation": "^8.2.0",
+        "@capacitor/haptics": "^8.0.2",
         "@capacitor/ios": "^8.4.0",
+        "@capacitor/share": "^8.0.1",
         "lucide": "^0.294.0"
       },
       "devDependencies": {
@@ -87,6 +90,27 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@capacitor/geolocation": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/geolocation/-/geolocation-8.2.0.tgz",
+      "integrity": "sha512-N29QcoIPmme0xSxRkm7+3hjoHp6mBAOarxecvtCCZKyOBeKiJsFUq981cezg2XWBa6fhCXJMCCjQPngKK/dIag==",
+      "license": "MIT",
+      "dependencies": {
+        "@capacitor/synapse": "^1.0.4"
+      },
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/haptics": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/haptics/-/haptics-8.0.2.tgz",
+      "integrity": "sha512-c2hZzRR5Fk1tbTvhG1jhh2XBAf3EhnIerMIb2sl7Mt41Gxx1fhBJFDa0/BI1IbY4loVepyyuqNC9820/GZuoWQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
     "node_modules/@capacitor/ios": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.4.0.tgz",
@@ -95,6 +119,21 @@
       "peerDependencies": {
         "@capacitor/core": "^8.4.0"
       }
+    },
+    "node_modules/@capacitor/share": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor/share/-/share-8.0.1.tgz",
+      "integrity": "sha512-3cSBKBCJVon54rKDROP2rqGyeGks4pBh9TbaEk9S375Kbek/ZHe72N50zIa0Vn9Eac/SuhwgehO/mmA4CsUOiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/synapse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.4.tgz",
+      "integrity": "sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw==",
+      "license": "ISC"
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.18.20",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
   },
   "dependencies": {
     "@capacitor/core": "^8.4.0",
+    "@capacitor/geolocation": "^8.2.0",
+    "@capacitor/haptics": "^8.0.2",
     "@capacitor/ios": "^8.4.0",
+    "@capacitor/share": "^8.0.1",
     "lucide": "^0.294.0"
   },
   "devDependencies": {

--- a/src/components/RestaurantCard.ts
+++ b/src/components/RestaurantCard.ts
@@ -1,4 +1,6 @@
 import { Restaurant } from '../types';
+import { Share } from '@capacitor/share';
+import { Haptics, ImpactStyle } from '@capacitor/haptics';
 
 export class RestaurantCard {
   constructor(private restaurant: Restaurant) {}
@@ -41,8 +43,45 @@ export class RestaurantCard {
           `).join('')}
         </div>
       </div>
+
+      <div class="mt-3 flex justify-end">
+        <button
+          class="share-btn inline-flex items-center gap-1.5 text-sm font-medium text-green-700 px-3 py-1.5 rounded-full hover:bg-green-50 active:bg-green-100 transition-colors"
+          aria-label="Share ${this.restaurant.name}"
+        >
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"/>
+          </svg>
+          Share
+        </button>
+      </div>
     `;
 
+    const shareBtn = card.querySelector('.share-btn');
+    shareBtn?.addEventListener('click', () => this.handleShare());
+
     return card;
+  }
+
+  private async handleShare(): Promise<void> {
+    // Light haptic tap on native devices; silently ignored on web.
+    try {
+      await Haptics.impact({ style: ImpactStyle.Light });
+    } catch {
+      // Haptics unsupported on this platform.
+    }
+
+    const { name, address, glutenFreeOptions, website } = this.restaurant;
+    try {
+      await Share.share({
+        title: name,
+        text: `${name} — ${address}\nGluten-free options: ${glutenFreeOptions.join(', ')}`,
+        url: website,
+        dialogTitle: 'Share this gluten-free spot'
+      });
+    } catch (error) {
+      // User dismissed the share sheet, or Share is unavailable on this platform.
+      console.debug('Share dismissed:', error);
+    }
   }
 }

--- a/src/services/geolocation.ts
+++ b/src/services/geolocation.ts
@@ -1,27 +1,32 @@
+import { Geolocation } from '@capacitor/geolocation';
+
 export async function getCurrentLocation(): Promise<{ lat: number; lng: number } | null> {
-  return new Promise((resolve) => {
-    if (!navigator.geolocation) {
-      console.log('Geolocation not supported');
-      resolve(null);
-      return;
+  try {
+    // On native iOS this triggers the system permission prompt (backed by the
+    // NSLocationWhenInUseUsageDescription string in Info.plist). On web the
+    // plugin delegates to the browser Geolocation API.
+    try {
+      const permission = await Geolocation.checkPermissions();
+      if (permission.location !== 'granted') {
+        await Geolocation.requestPermissions();
+      }
+    } catch {
+      // checkPermissions/requestPermissions is not available in every browser;
+      // getCurrentPosition still prompts on its own where supported.
     }
 
-    navigator.geolocation.getCurrentPosition(
-      (position) => {
-        resolve({
-          lat: position.coords.latitude,
-          lng: position.coords.longitude
-        });
-      },
-      (error) => {
-        console.error('Geolocation error:', error);
-        resolve(null);
-      },
-      {
-        enableHighAccuracy: true,
-        timeout: 10000,
-        maximumAge: 300000 // 5 minutes
-      }
-    );
-  });
+    const position = await Geolocation.getCurrentPosition({
+      enableHighAccuracy: true,
+      timeout: 10000,
+      maximumAge: 300000 // 5 minutes
+    });
+
+    return {
+      lat: position.coords.latitude,
+      lng: position.coords.longitude
+    };
+  } catch (error) {
+    console.error('Geolocation error:', error);
+    return null;
+  }
 }


### PR DESCRIPTION
## Warum

`docs/APP_STORE.md` warnt selbst vor **Guideline 4.2 (Minimum Functionality)** — zu dünne Web-Wrapper werden abgelehnt. Diese PR gibt der App native Substanz, ohne die PWA zu brechen (alle Features haben einen Web-Fallback).

## Was

- **`@capacitor/geolocation`** — native Standortabfrage mit System-Permission-Prompt (nutzt den vorhandenen `NSLocationWhenInUseUsageDescription`-String); im Web Fallback auf die Browser-Geolocation-API
- **`@capacitor/share`** — „Share"-Button pro Restaurant-Karte öffnet das native iOS-Share-Sheet (Name, Adresse, GF-Optionen, Website); im Web Web-Share-API
- **`@capacitor/haptics`** — leichtes haptisches Feedback beim Teilen (no-op im Web)
- `Package.swift` + `Package.resolved` um die 3 SPM-Plugins ergänzt (via `cap sync`)

## Nicht in Scope (bewusst)
- Offline-Caching / Service Worker → liegt bereits in offener PR #4
- Datenquellen-Umbau → PR #3

## Verifiziert
- `npm run build` ✅ grün (tsc + vite)
- `npx cap sync ios` ✅ registriert `geolocation@8.2.0`, `haptics@8.0.2`, `share@8.0.1`
- `npm run preview` + Browser ✅ echte OSM-Daten (München), Share-Button auf jeder Karte mit korrektem aria-Label, keine JS-Fehler, OSM-Attribution intakt

## Hinweis
Auf einem echten Gerät/Simulator getestet werden konnte es noch nicht (lokale Xcode-Simulator-Runtime fehlt, separates Umgebungsthema). Die Web-Verifikation deckt die Fallback-Pfade ab; die nativen Pfade greifen erst auf dem Device.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)