### PR TITLE
chore: automated npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1054,9 +1054,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1526,9 +1526,10 @@
       }
     },
     "node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1811,13 +1812,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -1869,9 +1870,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2034,9 +2035,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2082,9 +2083,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2102,7 +2103,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2377,16 +2378,16 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/rimraf/node_modules/glob": {
@@ -2451,9 +2452,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.29.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
-      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
+      "version": "3.30.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.30.0.tgz",
+      "integrity": "sha512-kQvGasUgN+AlWGliFn2POSajRQEsULVYFGTvOZmK06d7vCD+YhZztt70kGk3qaeAXeWYL5eO7zx+rAubBc55eA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2818,9 +2819,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -3197,9 +3198,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3207,6 +3208,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yauzl": {


### PR DESCRIPTION
## Summary

Automated weekly dependency-hygiene run. `npm audit fix` (no `--force`) resolved 9 of 11 known vulnerabilities by bumping transitive dependencies in `package-lock.json`. No direct dependency versions in `package.json` changed.

### Fixed (via `npm audit fix`, non-breaking)

| Package | Severity | Advisories |
|---|---|---|
| `tar` | critical | GHSA-23hp-3jrh-7fpw (Decompression/parse DoS), GHSA-8x88-c5mf-7j5w, GHSA-w8wr-v893-vjvp, GHSA-gvwx-54wh-qm9j, GHSA-r292-9mhp-454m |
| `brace-expansion` | high | GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895, GHSA-f886-m6hf-6m8v (DoS via exponential/unbounded expansion) |
| `glob` | high | GHSA-5j98-mcp5-4vw2 (CLI command injection via `-c/--cmd`) |
| `minimatch` | high | GHSA-3ppc-4f35-3m26, GHSA-7r86-cg39-jmmj, GHSA-23c5-xmqv-rm74 (ReDoS) |
| `nanoid` | high | GHSA-28wg-ghj8-5hjv, GHSA-2v37-7h3g-55p8 (indefinite loop) |
| `picomatch` | high | GHSA-c2c7-rcm5-vvqj (ReDoS), GHSA-3v7f-55p6-f55p |
| `postcss` | high | GHSA-6g55-p6wh-862q, GHSA-r28c-9q8g-f849 (arbitrary file read via sourceMappingURL), GHSA-fxqj-rqcc-2cmp, GHSA-qx2v-qp2m-jg93 |
| `rollup` | high | GHSA-mw96-cpmx-2vgc (arbitrary file write via path traversal) |
| `yaml` | moderate | GHSA-48c2-rrv3-qjmp (stack overflow via deeply nested collections) |

### NOT fixed (requires a major/breaking bump — left for manual review)

| Package | Issue | Fix path |
|---|---|---|
| `esbuild` | moderate — dev server accepts requests from any website (GHSA-67mh-4wv8-2f99) | `npm audit fix --force` → would install `vite@8.2.1` (breaking, current is `vite@4.5.14`) |
| `vite` | high — depends on vulnerable esbuild | same as above |

Per this routine's constraints, `--force` was not used and no major version bumps were applied. These need a deliberate, manually-reviewed Vite 4 → 8 upgrade (large jump, likely has other breaking changes beyond esbuild).

### `npm outdated` (informational only, nothing auto-bumped)

| Package | Current | Wanted | Latest | Bump type |
|---|---|---|---|---|
| `@capacitor/cli` | 8.4.0 | 8.5.0 | 8.5.0 | patch |
| `@capacitor/core` | 8.4.0 | 8.5.0 | 8.5.0 | patch |
| `@capacitor/ios` | 8.4.0 | 8.5.0 | 8.5.0 | patch |
| `@types/node` | 20.19.14 | 20.19.43 | 26.2.0 | patch (wanted) / major (latest) |
| `autoprefixer` | 10.4.21 | 10.5.4 | 10.5.4 | patch |
| `lucide` | 0.294.0 | 0.294.0 | 1.31.0 | major |
| `postcss` | 8.5.6 | 8.5.26 | 8.5.26 | patch |
| `tailwindcss` | 3.4.17 | 3.4.19 | 4.3.3 | patch (wanted) / major (latest) |
| `typescript` | 5.9.2 | 5.9.3 | 7.0.2 | patch (wanted) / major (latest) |
| `vite` | 4.5.14 | 4.5.14 | 8.2.1 | major |

## Test plan

- [x] `npm ci` — clean install from lockfile
- [x] `npm audit fix` (no `--force`) — applied, only `package-lock.json` changed
- [x] `npm run build` (`tsc && vite build`) — passed after the fix, output unchanged in shape (`dist/index.html`, `dist/assets/*.css`, `dist/assets/*.js`)
- [x] `git diff --stat` — only `package-lock.json` touched (37 insertions, 33 deletions), no `package.json` changes

---

🤖 Automated weekly dependency-hygiene routine.
Co-Authored-By: Claude <noreply@anthropic.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01AkJ4vn5v6o9NkRdwQMNh9v)_