### PR TITLE
feat(ci): @claude-Mention-Responder als Review-Fallback-Stufe 1

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,61 @@
+name: Claude
+
+# @claude-Mention-Responder (Review-Fallback-Stufe "claude")
+# ----------------------------------------------------------
+# Reagiert auf @claude-Mentions in PR-/Issue-Kommentaren, Review-Kommentaren
+# und Issues. Das ist die Voraussetzung der Review-Fallback-Kette
+# (flos-claude-skills/references/review-fallbacks.yaml, Stufe "claude"):
+# Ohne diese Datei auf dem DEFAULT-Branch ist die Claude-App auf Mentions
+# taub — issue_comment-Events laden den Workflow immer von main, die Datei
+# wirkt also erst NACH dem Merge.
+#
+# Die claude-code-action prüft selbst, ob der mentionende Account
+# Schreibrechte im Repo hat — fremde Mentions starten keinen Lauf.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    if: >
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # write (nicht read): sonst läuft der Job grün durch, kann aber keine
+      # Review-/Inline-Kommentare auf den PR schreiben (stiller No-op).
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Claude darf CI-Ergebnisse des PR lesen.
+
+    steps:
+      # Actions auf Commit-SHA gepinnt (Supply-Chain-Härtung).
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 1
+          # Kein GITHUB_TOKEN in .git/config hinterlegen — die Action bringt
+          # ihre eigene Auth mit (Härtung, zizmor-Finding).
+          persist-credentials: false
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@428971d2ecd6e3a7cb0ee0da2a3a8b33fdb3678d # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Workflow-Permissions allein reichen nicht: Auch der App-Token der
+          # Action braucht actions: read, damit Claude CI-Ergebnisse lesen kann.
+          additional_permissions: |
+            actions: read


### PR DESCRIPTION
Ergänzt den `@claude`-Mention-Responder als **Stufe 1 der Review-Fallback-Kette**.

## Warum

`flos-claude-skills/references/review-fallbacks.yaml` sieht vor: Ist CodeRabbit nicht verfügbar (Rate-Limit, Spending-Cap, Incident), übernimmt `@claude`. Diese Stufe braucht laut `requires` ein `claude.yml` auf dem **Default-Branch** — `issue_comment`-Events laden den Workflow immer von dort, eine Datei im Feature-Branch reicht nicht.

Eine Erhebung über alle 72 aktiven Repos am 28.08.2026 ergab: **`claude.yml` existiert in 8 Repos, in 19 der 27 Repos mit PR-Betrieb fehlt sie.** Die Fallback-Stufe war dort also nicht etwa langsam, sondern **taub** — ein `@claude` löst nichts aus, ohne Fehlermeldung.

Das ist real geworden: In einer Session am 28.08. lief CodeRabbit viermal ins Rate-Limit, und es gab keine abrufbare zweite Stufe. Ein vorhandenes `claude-review.yml` hilft dort nicht — das reviewt auf Push, lässt sich aber nicht auf Zuruf holen.

## Was drin ist

Die unveränderte, gehärtete Vorlage aus `drfloriansteiner.com`:

- reagiert auf `@claude` in PR-/Issue-Kommentaren, Review-Kommentaren und Issues
- Actions auf Commit-SHA gepinnt, `persist-credentials: false`
- `pull-requests: write` (nicht `read`) — sonst läuft der Job grün durch, kann aber nichts schreiben
- `additional_permissions: actions: read`, damit Claude CI-Ergebnisse des PR lesen kann
- die Action prüft selbst, ob der mentionende Account Schreibrechte hat

Das Secret `CLAUDE_CODE_OAUTH_TOKEN` ist in diesem Repo bereits gesetzt — geprüft, bevor der PR angelegt wurde. Repos ohne das Secret sind bewusst **nicht** Teil des Rollouts, dort wäre die Datei ein stummer Workflow.

## Bestehende Review-Workflows bleiben unberührt

Ein vorhandenes `claude-review.yml` oder `claude-code-review.yml` wird nicht angefasst. Die beiden ergänzen sich: das eine reviewt automatisch auf Push, dieses hier ist der abrufbare Fallback.

Vorgang: ProduktEntdecker/flos-claude-skills#158
